### PR TITLE
Add VLESS subscription import

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - Classic VPN-protocols: OpenVPN, WireGuard and IKEv2 protocols.
 - Protocols with traffic Masking (Obfuscation): OpenVPN over [Cloak](https://github.com/cbeuw/Cloak) plugin, Shadowsocks (OpenVPN over Shadowsocks), [AmneziaWG](https://docs.amnezia.org/documentation/amnezia-wg/) and XRay.
 - Split tunneling support - add any sites to the client to enable VPN only for them or add Apps (only for Android and Desktop).
+- Import multiple VLESS servers from a subscription URL.
 - Windows, MacOS, Linux, Android, iOS releases.
 - Support for AmneziaWG protocol configuration on [Keenetic beta firmware](https://docs.keenetic.com/ua/air/kn-1611/en/6319-latest-development-release.html#UUID-186c4108-5afd-c10b-f38a-cdff6c17fab3_section-idm33192196168192-improved).
 

--- a/client/translations/amneziavpn_ar_EG.ts
+++ b/client/translations/amneziavpn_ar_EG.ts
@@ -2909,6 +2909,16 @@ Already installed containers were found on the server. All installed containers 
         <source>I have nothing</source>
         <translation>ليس لدي اي شئ</translation>
     </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="187"/>
+        <source>Subscription URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="201"/>
+        <source>Load subscription</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PageSetupWizardCredentials</name>

--- a/client/translations/amneziavpn_fa_IR.ts
+++ b/client/translations/amneziavpn_fa_IR.ts
@@ -3029,6 +3029,16 @@ It&apos;s okay as long as it&apos;s from someone you trust.</source>
         <translation>من هیچی ندارم</translation>
     </message>
     <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="187"/>
+        <source>Subscription URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="201"/>
+        <source>Load subscription</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Key as text</source>
         <translation type="vanished">متن شامل کلید</translation>
     </message>

--- a/client/translations/amneziavpn_hi_IN.ts
+++ b/client/translations/amneziavpn_hi_IN.ts
@@ -2929,6 +2929,16 @@ Already installed containers were found on the server. All installed containers 
         <source>Key as text</source>
         <translation type="vanished">पाठ के रूप में कुंजी</translation>
     </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="187"/>
+        <source>Subscription URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="201"/>
+        <source>Load subscription</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PageSetupWizardCredentials</name>

--- a/client/translations/amneziavpn_my_MM.ts
+++ b/client/translations/amneziavpn_my_MM.ts
@@ -2922,6 +2922,16 @@ Already installed containers were found on the server. All installed containers 
         <source>I have nothing</source>
         <translation>ကျွန်ုပ်တွင်ဘာမှမရှိပါ</translation>
     </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="187"/>
+        <source>Subscription URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="201"/>
+        <source>Load subscription</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PageSetupWizardCredentials</name>

--- a/client/translations/amneziavpn_ru_RU.ts
+++ b/client/translations/amneziavpn_ru_RU.ts
@@ -3262,6 +3262,16 @@ Thank you for staying with us!</source>
         <source>I have nothing</source>
         <translation>У меня ничего нет</translation>
     </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="187"/>
+        <source>Subscription URL</source>
+        <translation>URL подписки</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="201"/>
+        <source>Load subscription</source>
+        <translation>Загрузить подписку</translation>
+    </message>
 </context>
 <context>
     <name>PageSetupWizardCredentials</name>

--- a/client/translations/amneziavpn_uk_UA.ts
+++ b/client/translations/amneziavpn_uk_UA.ts
@@ -3187,6 +3187,16 @@ It&apos;s okay as long as it&apos;s from someone you trust.</source>
         <translation>У мене нічого нема</translation>
     </message>
     <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="187"/>
+        <source>Subscription URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="201"/>
+        <source>Load subscription</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Key as text</source>
         <translation type="vanished">Ключ у вигляді тексту</translation>
     </message>

--- a/client/translations/amneziavpn_ur_PK.ts
+++ b/client/translations/amneziavpn_ur_PK.ts
@@ -2918,6 +2918,16 @@ Already installed containers were found on the server. All installed containers 
         <translation type="unfinished">میرے پاس کچھ نہیں ہے</translation>
     </message>
     <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="187"/>
+        <source>Subscription URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="201"/>
+        <source>Load subscription</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Key as text</source>
         <translation type="vanished">متن کے طور پر کلید</translation>
     </message>

--- a/client/translations/amneziavpn_zh_CN.ts
+++ b/client/translations/amneziavpn_zh_CN.ts
@@ -3069,6 +3069,16 @@ It&apos;s okay as long as it&apos;s from someone you trust.</source>
         <translation type="unfinished">我没有</translation>
     </message>
     <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="187"/>
+        <source>Subscription URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="201"/>
+        <source>Load subscription</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Key as text</source>
         <translation type="vanished">授权码文本</translation>
     </message>

--- a/client/ui/controllers/importController.cpp
+++ b/client/ui/controllers/importController.cpp
@@ -6,6 +6,10 @@
 #include <QRandomGenerator>
 #include <QStandardPaths>
 #include <QUrlQuery>
+#include <QEventLoop>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include "amnezia_application.h"
 
 #include "core/api/apiDefs.h"
 #include "core/api/apiUtils.h"
@@ -98,6 +102,11 @@ bool ImportController::extractConfigFromData(QString data)
     m_maliciousWarningText.clear();
 
     QString config = data;
+    if (config.startsWith("http://") || config.startsWith("https://")) {
+        if (importVlessSubscription(config)) {
+            return false;
+        }
+    }
     QString prefix;
     QString errormsg;
 
@@ -339,6 +348,55 @@ void ImportController::importConfig()
     m_config = {};
     m_configFileName.clear();
     m_maliciousWarningText.clear();
+}
+
+bool ImportController::importVlessSubscription(const QString &subscriptionUrl)
+{
+    QUrl url(subscriptionUrl);
+    if (!url.isValid()) {
+        return false;
+    }
+
+    QNetworkReply *reply = amnApp->networkManager()->get(QNetworkRequest(url));
+    QEventLoop loop;
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    QByteArray data = reply->error() == QNetworkReply::NoError ? reply->readAll() : QByteArray();
+    reply->deleteLater();
+    if (data.isEmpty()) {
+        return false;
+    }
+
+    QByteArray decoded = QByteArray::fromBase64(data.trimmed());
+    if (decoded.isEmpty()) {
+        decoded = data;
+    }
+
+    QList<QByteArray> links = decoded.split('\n');
+    bool added = false;
+    for (const QByteArray &ba : links) {
+        QString link = QString::fromUtf8(ba).trimmed();
+        if (!link.startsWith("vless://")) {
+            continue;
+        }
+        QString prefix;
+        QString err;
+        QJsonObject obj = serialization::vless::Deserialize(link, &prefix, &err);
+        if (obj.isEmpty()) {
+            continue;
+        }
+        m_configType = ConfigTypes::Xray;
+        QJsonObject server = extractXrayConfig(Utils::JsonToString(obj, QJsonDocument::JsonFormat::Compact), prefix);
+        if (!server.isEmpty()) {
+            m_serversModel->addServer(server);
+            added = true;
+        }
+    }
+    if (added) {
+        emit importFinished();
+    }
+    return added;
 }
 
 QJsonObject ImportController::extractOpenVpnConfig(const QString &data)

--- a/client/ui/controllers/importController.h
+++ b/client/ui/controllers/importController.h
@@ -32,6 +32,7 @@ public slots:
     void importConfig();
     bool extractConfigFromFile(const QString &fileName);
     bool extractConfigFromData(QString data);
+    bool importVlessSubscription(const QString &subscriptionUrl);
     bool extractConfigFromQr(const QByteArray &data);
     QString getConfig();
     QString getConfigFileName();

--- a/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml
+++ b/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml
@@ -185,6 +185,42 @@ PageType {
                 }
             }
 
+            TextFieldWithHeaderType {
+                id: subscriptionUrl
+
+                Layout.fillWidth: true
+                Layout.topMargin: 16
+                Layout.rightMargin: 16
+                Layout.leftMargin: 16
+
+                headerText: qsTr("Subscription URL")
+                buttonText: qsTr("Insert")
+
+                clickedFunc: function() {
+                    textField.text = ""
+                    textField.paste()
+                }
+            }
+
+            BasicButtonType {
+                id: loadSubscriptionButton
+
+                Layout.fillWidth: true
+                Layout.topMargin: 16
+                Layout.rightMargin: 16
+                Layout.leftMargin: 16
+
+                visible: subscriptionUrl.textField.text !== ""
+
+                text: qsTr("Load subscription")
+
+                clickedFunc: function() {
+                    if (ImportController.importVlessSubscription(subscriptionUrl.textField.text)) {
+                        PageController.goToPageHome()
+                    }
+                }
+            }
+
             BasicButtonType {
                 id: continueButton
 


### PR DESCRIPTION
## Summary
- support importing multiple servers from VLESS subscription URLs
- detect subscription URLs in import wizard
- expose subscription import in the setup wizard UI
- document feature in README
- update translations

## Testing
- `cmake -S . -B build` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_687e2d1acfe88324bffa33fdc8bf34fd